### PR TITLE
Introduce `Needle` trait to make `Avx2Searcher` generic over it's needle

### DIFF
--- a/src/x86.rs
+++ b/src/x86.rs
@@ -1,11 +1,24 @@
 #![allow(clippy::missing_safety_doc)]
 
-use crate::{bits, memcmp, MemchrSearcher};
+use crate::{bits, memcmp, MemchrSearcher, Needle};
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
 use std::mem;
+
+trait NeedleWithSize: Needle {
+    #[inline]
+    fn size(&self) -> usize {
+        if let Some(size) = Self::SIZE {
+            size
+        } else {
+            self.as_bytes().len()
+        }
+    }
+}
+
+impl<N: Needle + ?Sized> NeedleWithSize for N {}
 
 /// Rolling hash for the simple Rabin-Karp implementation. As a hashing
 /// function, the sum of all the bytes is computed.
@@ -132,222 +145,216 @@ impl<V: Vector> VectorHash<V> {
     }
 }
 
-macro_rules! avx2_searcher {
-    ($name:ident, $size:literal, $memcmp:path) => {
-        /// Single-substring searcher using an AVX2 algorithm based on the
-        /// "Generic SIMD" algorithm [presented by Wojciech
-        /// Muła](http://0x80.pl/articles/simd-strfind.html).
-        ///
-        /// It is similar to the Rabin-Karp algorithm, except that the hash is
-        /// not rolling and is calculated for several lanes at once. It begins
-        /// by picking the first byte in the needle and checking at which
-        /// positions in the haystack it occurs. Any position where it does not
-        /// can be immediately discounted as a potential match.
-        ///
-        /// We then repeat this idea with a second byte in the needle (where the
-        /// haystack is suitably offset) and take a bitwise AND to further limit
-        /// the possible positions the needle can match in. Any remaining
-        /// positions are fully evaluated using an equality comparison with the
-        /// needle.
-        ///
-        /// Originally, the algorithm always used the last byte for this second
-        /// byte. Whilst this is often the most efficient option, it is
-        /// vulnerable to a worst-case attack and so this implementation instead
-        /// allows any byte (including a random one) to be chosen.
-        ///
-        /// In the case where the needle is not a multiple of the number of SIMD
-        /// lanes, the last chunk is made up of a partial overlap with the
-        /// penultimate chunk to avoid reading random memory, differing from the
-        /// original implementation. In this case, a mask is used to prevent
-        /// performing an equality comparison on the same position twice.
-        ///
-        /// When the haystack is too short for an AVX2 register, a similar SSE2
-        /// fallback is used instead. Finally, for very short haystacks there is
-        /// a scalar Rabin-Karp implementation.
-        pub struct $name {
-            needle: Box<[u8]>,
-            position: usize,
-            scalar_hash: ScalarHash,
-            sse2_hash: VectorHash<__m128i>,
-            avx2_hash: VectorHash<__m256i>,
-        }
-
-        impl $name {
-            /// Creates a new searcher for `needle`. By default, `position` is
-            /// set to the last character in the needle.
-            #[target_feature(enable = "avx2")]
-            pub unsafe fn new(needle: Box<[u8]>) -> Self {
-                let position = needle.len() - 1;
-                Self::with_position(needle, position)
-            }
-
-            /// Same as `new` but allows additionally specifying the `position`
-            /// to use.
-            #[target_feature(enable = "avx2")]
-            pub unsafe fn with_position(needle: Box<[u8]>, position: usize) -> Self {
-                assert!(!needle.is_empty());
-                assert!(position < needle.len());
-
-                let scalar_hash = ScalarHash::from(needle.as_ref());
-                let sse2_hash = VectorHash::new(needle[0], needle[position]);
-                let avx2_hash = VectorHash::new(needle[0], needle[position]);
-
-                Self {
-                    needle,
-                    position,
-                    scalar_hash,
-                    sse2_hash,
-                    avx2_hash,
-                }
-            }
-
-            #[inline]
-            fn size(&self) -> usize {
-                if $size > 0 {
-                    $size
-                } else {
-                    self.needle.len()
-                }
-            }
-
-            #[inline]
-            fn scalar_search_in(&self, haystack: &[u8]) -> bool {
-                debug_assert!(haystack.len() >= self.size());
-
-                let mut end = self.size() - 1;
-                let mut hash = ScalarHash::from(&haystack[..end]);
-
-                while end < haystack.len() {
-                    hash.push(*unsafe { haystack.get_unchecked(end) });
-                    end += 1;
-
-                    let start = end - self.size();
-                    if hash == self.scalar_hash && haystack[start..end] == *self.needle {
-                        return true;
-                    }
-
-                    hash.pop(*unsafe { haystack.get_unchecked(start) });
-                }
-
-                false
-            }
-
-            #[inline]
-            #[target_feature(enable = "avx2")]
-            unsafe fn vector_search_in_chunk<V: Vector>(
-                &self,
-                haystack: &[u8],
-                hash: &VectorHash<V>,
-                start: *const u8,
-                mask: i32,
-            ) -> bool {
-                let first = Vector::loadu_si(start.cast());
-                let last = Vector::loadu_si(start.add(self.position).cast());
-
-                let eq_first = Vector::cmpeq_epi8(hash.first, first);
-                let eq_last = Vector::cmpeq_epi8(hash.last, last);
-
-                let eq = Vector::and_si(eq_first, eq_last);
-                let mut eq = (Vector::movemask_epi8(eq) & mask) as u32;
-
-                let start = start as usize - haystack.as_ptr() as usize;
-                let chunk = haystack.as_ptr().add(start + 1);
-                let needle = self.needle.as_ptr().add(1);
-
-                while eq != 0 {
-                    let chunk = chunk.add(eq.trailing_zeros() as usize);
-                    if $memcmp(chunk, needle, self.size() - 1) {
-                        return true;
-                    }
-
-                    eq = bits::clear_leftmost_set(eq);
-                }
-
-                false
-            }
-
-            #[inline]
-            #[target_feature(enable = "avx2")]
-            unsafe fn vector_search_in<V: Vector>(
-                &self,
-                haystack: &[u8],
-                hash: &VectorHash<V>,
-                next: unsafe fn(&Self, &[u8]) -> bool,
-            ) -> bool {
-                debug_assert!(haystack.len() >= self.size());
-
-                let lanes = mem::size_of::<V>();
-                let end = haystack.len() - self.size() + 1;
-
-                if end < lanes {
-                    return next(self, haystack);
-                }
-
-                let mut chunks = haystack[..end].chunks_exact(lanes);
-                while let Some(chunk) = chunks.next() {
-                    if self.vector_search_in_chunk(haystack, hash, chunk.as_ptr(), -1) {
-                        return true;
-                    }
-                }
-
-                let remainder = chunks.remainder().len();
-                if remainder > 0 {
-                    let start = haystack.as_ptr().add(end - lanes);
-                    let mask = -1 << (lanes - remainder);
-
-                    if self.vector_search_in_chunk(haystack, hash, start, mask) {
-                        return true;
-                    }
-                }
-
-                false
-            }
-
-            #[inline]
-            #[target_feature(enable = "avx2")]
-            unsafe fn sse2_search_in(&self, haystack: &[u8]) -> bool {
-                self.vector_search_in(haystack, &self.sse2_hash, Self::scalar_search_in)
-            }
-
-            #[inline]
-            #[target_feature(enable = "avx2")]
-            unsafe fn avx2_search_in(&self, haystack: &[u8]) -> bool {
-                self.vector_search_in(haystack, &self.avx2_hash, Self::sse2_search_in)
-            }
-
-            /// Inlined version of `search_in` for hot call sites.
-            #[inline]
-            #[target_feature(enable = "avx2")]
-            pub unsafe fn inlined_search_in(&self, haystack: &[u8]) -> bool {
-                if haystack.len() < self.size() {
-                    return false;
-                }
-
-                self.avx2_search_in(haystack)
-            }
-
-            /// Performs a substring search for the `needle` within `haystack`.
-            #[target_feature(enable = "avx2")]
-            pub unsafe fn search_in(&self, haystack: &[u8]) -> bool {
-                self.inlined_search_in(haystack)
-            }
-        }
-    };
+/// Single-substring searcher using an AVX2 algorithm based on the
+/// "Generic SIMD" algorithm [presented by Wojciech
+/// Muła](http://0x80.pl/articles/simd-strfind.html).
+///
+/// It is similar to the Rabin-Karp algorithm, except that the hash is
+/// not rolling and is calculated for several lanes at once. It begins
+/// by picking the first byte in the needle and checking at which
+/// positions in the haystack it occurs. Any position where it does not
+/// can be immediately discounted as a potential match.
+///
+/// We then repeat this idea with a second byte in the needle (where the
+/// haystack is suitably offset) and take a bitwise AND to further limit
+/// the possible positions the needle can match in. Any remaining
+/// positions are fully evaluated using an equality comparison with the
+/// needle.
+///
+/// Originally, the algorithm always used the last byte for this second
+/// byte. Whilst this is often the most efficient option, it is
+/// vulnerable to a worst-case attack and so this implementation instead
+/// allows any byte (including a random one) to be chosen.
+///
+/// In the case where the needle is not a multiple of the number of SIMD
+/// lanes, the last chunk is made up of a partial overlap with the
+/// penultimate chunk to avoid reading random memory, differing from the
+/// original implementation. In this case, a mask is used to prevent
+/// performing an equality comparison on the same position twice.
+///
+/// When the haystack is too short for an AVX2 register, a similar SSE2
+/// fallback is used instead. Finally, for very short haystacks there is
+/// a scalar Rabin-Karp implementation.
+pub struct Avx2Searcher<N: Needle> {
+    position: usize,
+    scalar_hash: ScalarHash,
+    sse2_hash: VectorHash<__m128i>,
+    avx2_hash: VectorHash<__m256i>,
+    needle: N,
 }
 
-avx2_searcher!(Avx2Searcher, 0, memcmp::memcmp);
-avx2_searcher!(Avx2Searcher2, 2, memcmp::memcmp1);
-avx2_searcher!(Avx2Searcher3, 3, memcmp::memcmp2);
-avx2_searcher!(Avx2Searcher4, 4, memcmp::memcmp3);
-avx2_searcher!(Avx2Searcher5, 5, memcmp::memcmp4);
-avx2_searcher!(Avx2Searcher6, 6, memcmp::memcmp5);
-avx2_searcher!(Avx2Searcher7, 7, memcmp::memcmp6);
-avx2_searcher!(Avx2Searcher8, 8, memcmp::memcmp7);
-avx2_searcher!(Avx2Searcher9, 9, memcmp::memcmp8);
-avx2_searcher!(Avx2Searcher10, 10, memcmp::memcmp9);
-avx2_searcher!(Avx2Searcher11, 11, memcmp::memcmp10);
-avx2_searcher!(Avx2Searcher12, 12, memcmp::memcmp11);
-avx2_searcher!(Avx2Searcher13, 13, memcmp::memcmp12);
+impl<N: Needle> Avx2Searcher<N> {
+    /// Creates a new searcher for `needle`. By default, `position` is
+    /// set to the last character in the needle.
+    #[target_feature(enable = "avx2")]
+    pub unsafe fn new(needle: N) -> Self {
+        let position = needle.size() - 1;
+        Self::with_position(needle, position)
+    }
+
+    /// Same as `new` but allows additionally specifying the `position`
+    /// to use.
+    #[target_feature(enable = "avx2")]
+    pub unsafe fn with_position(needle: N, position: usize) -> Self {
+        let bytes = needle.as_bytes();
+        assert!(!bytes.is_empty());
+        assert!(position < bytes.len());
+        if let Some(size) = N::SIZE {
+            assert_eq!(size, bytes.len());
+        }
+
+        let scalar_hash = ScalarHash::from(bytes);
+        let sse2_hash = VectorHash::new(bytes[0], bytes[position]);
+        let avx2_hash = VectorHash::new(bytes[0], bytes[position]);
+
+        Self {
+            needle,
+            position,
+            scalar_hash,
+            sse2_hash,
+            avx2_hash,
+        }
+    }
+
+    #[inline]
+    fn scalar_search_in(&self, haystack: &[u8]) -> bool {
+        debug_assert!(haystack.len() >= self.needle.size());
+
+        let mut end = self.needle.size() - 1;
+        let mut hash = ScalarHash::from(&haystack[..end]);
+
+        while end < haystack.len() {
+            hash.push(*unsafe { haystack.get_unchecked(end) });
+            end += 1;
+
+            let start = end - self.needle.size();
+            if hash == self.scalar_hash && haystack[start..end] == *self.needle.as_bytes() {
+                return true;
+            }
+
+            hash.pop(*unsafe { haystack.get_unchecked(start) });
+        }
+
+        false
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx2")]
+    unsafe fn vector_search_in_chunk<V: Vector>(
+        &self,
+        haystack: &[u8],
+        hash: &VectorHash<V>,
+        start: *const u8,
+        mask: i32,
+    ) -> bool {
+        let first = Vector::loadu_si(start.cast());
+        let last = Vector::loadu_si(start.add(self.position).cast());
+
+        let eq_first = Vector::cmpeq_epi8(hash.first, first);
+        let eq_last = Vector::cmpeq_epi8(hash.last, last);
+
+        let eq = Vector::and_si(eq_first, eq_last);
+        let mut eq = (Vector::movemask_epi8(eq) & mask) as u32;
+
+        let start = start as usize - haystack.as_ptr() as usize;
+        let chunk = haystack.as_ptr().add(start + 1);
+        let needle = self.needle.as_bytes().as_ptr().add(1);
+
+        while eq != 0 {
+            let chunk = chunk.add(eq.trailing_zeros() as usize);
+            let equal = match N::SIZE {
+                Some(0) => unreachable!(),
+                Some(1) => memcmp::memcmp0(chunk, needle, 0),
+                Some(2) => memcmp::memcmp1(chunk, needle, 1),
+                Some(3) => memcmp::memcmp2(chunk, needle, 2),
+                Some(4) => memcmp::memcmp3(chunk, needle, 3),
+                Some(5) => memcmp::memcmp4(chunk, needle, 4),
+                Some(6) => memcmp::memcmp5(chunk, needle, 5),
+                Some(7) => memcmp::memcmp6(chunk, needle, 6),
+                Some(8) => memcmp::memcmp7(chunk, needle, 7),
+                Some(9) => memcmp::memcmp8(chunk, needle, 8),
+                Some(10) => memcmp::memcmp9(chunk, needle, 9),
+                Some(11) => memcmp::memcmp10(chunk, needle, 10),
+                Some(12) => memcmp::memcmp11(chunk, needle, 11),
+                Some(13) => memcmp::memcmp12(chunk, needle, 12),
+                _ => memcmp::memcmp(chunk, needle, self.needle.size() - 1),
+            };
+            if equal {
+                return true;
+            }
+
+            eq = bits::clear_leftmost_set(eq);
+        }
+
+        false
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx2")]
+    unsafe fn vector_search_in<V: Vector>(
+        &self,
+        haystack: &[u8],
+        hash: &VectorHash<V>,
+        next: unsafe fn(&Self, &[u8]) -> bool,
+    ) -> bool {
+        debug_assert!(haystack.len() >= self.needle.size());
+
+        let lanes = mem::size_of::<V>();
+        let end = haystack.len() - self.needle.size() + 1;
+
+        if end < lanes {
+            return next(self, haystack);
+        }
+
+        let mut chunks = haystack[..end].chunks_exact(lanes);
+        while let Some(chunk) = chunks.next() {
+            if self.vector_search_in_chunk(haystack, hash, chunk.as_ptr(), -1) {
+                return true;
+            }
+        }
+
+        let remainder = chunks.remainder().len();
+        if remainder > 0 {
+            let start = haystack.as_ptr().add(end - lanes);
+            let mask = -1 << (lanes - remainder);
+
+            if self.vector_search_in_chunk(haystack, hash, start, mask) {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx2")]
+    unsafe fn sse2_search_in(&self, haystack: &[u8]) -> bool {
+        self.vector_search_in(haystack, &self.sse2_hash, Self::scalar_search_in)
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx2")]
+    unsafe fn avx2_search_in(&self, haystack: &[u8]) -> bool {
+        self.vector_search_in(haystack, &self.avx2_hash, Self::sse2_search_in)
+    }
+
+    /// Inlined version of `search_in` for hot call sites.
+    #[inline]
+    #[target_feature(enable = "avx2")]
+    pub unsafe fn inlined_search_in(&self, haystack: &[u8]) -> bool {
+        if haystack.len() < self.needle.size() {
+            return false;
+        }
+
+        self.avx2_search_in(haystack)
+    }
+
+    /// Performs a substring search for the `needle` within `haystack`.
+    #[target_feature(enable = "avx2")]
+    pub unsafe fn search_in(&self, haystack: &[u8]) -> bool {
+        self.inlined_search_in(haystack)
+    }
+}
 
 /// Single-substring searcher based on `Avx2Searcher` but with dynamic algorithm
 /// selection.
@@ -363,31 +370,31 @@ pub enum DynamicAvx2Searcher {
     /// Specialization for needles with length 1.
     N1(MemchrSearcher),
     /// Specialization for needles with length 2.
-    N2(Avx2Searcher2),
+    N2(Avx2Searcher<[u8; 2]>),
     /// Specialization for needles with length 3.
-    N3(Avx2Searcher3),
+    N3(Avx2Searcher<[u8; 3]>),
     /// Specialization for needles with length 4.
-    N4(Avx2Searcher4),
+    N4(Avx2Searcher<[u8; 4]>),
     /// Specialization for needles with length 5.
-    N5(Avx2Searcher5),
+    N5(Avx2Searcher<[u8; 5]>),
     /// Specialization for needles with length 6.
-    N6(Avx2Searcher6),
+    N6(Avx2Searcher<[u8; 6]>),
     /// Specialization for needles with length 7.
-    N7(Avx2Searcher7),
+    N7(Avx2Searcher<[u8; 7]>),
     /// Specialization for needles with length 8.
-    N8(Avx2Searcher8),
+    N8(Avx2Searcher<[u8; 8]>),
     /// Specialization for needles with length 9.
-    N9(Avx2Searcher9),
+    N9(Avx2Searcher<[u8; 9]>),
     /// Specialization for needles with length 10.
-    N10(Avx2Searcher10),
+    N10(Avx2Searcher<[u8; 10]>),
     /// Specialization for needles with length 11.
-    N11(Avx2Searcher11),
+    N11(Avx2Searcher<[u8; 11]>),
     /// Specialization for needles with length 12.
-    N12(Avx2Searcher12),
+    N12(Avx2Searcher<[u8; 12]>),
     /// Specialization for needles with length 13.
-    N13(Avx2Searcher13),
+    N13(Avx2Searcher<[u8; 13]>),
     /// Fallback implementation for needles of any size.
-    N(Avx2Searcher),
+    N(Avx2Searcher<Box<[u8]>>),
 }
 
 impl DynamicAvx2Searcher {
@@ -405,21 +412,37 @@ impl DynamicAvx2Searcher {
         assert!(!needle.is_empty());
         assert!(position < needle.len());
 
-        match needle.len() {
-            0 => Self::N0,
-            1 => Self::N1(MemchrSearcher::new(needle[0])),
-            2 => Self::N2(Avx2Searcher2::new(needle)),
-            3 => Self::N3(Avx2Searcher3::new(needle)),
-            4 => Self::N4(Avx2Searcher4::new(needle)),
-            5 => Self::N5(Avx2Searcher5::new(needle)),
-            6 => Self::N6(Avx2Searcher6::new(needle)),
-            7 => Self::N7(Avx2Searcher7::new(needle)),
-            8 => Self::N8(Avx2Searcher8::new(needle)),
-            9 => Self::N9(Avx2Searcher9::new(needle)),
-            10 => Self::N10(Avx2Searcher10::new(needle)),
-            11 => Self::N11(Avx2Searcher11::new(needle)),
-            12 => Self::N12(Avx2Searcher12::new(needle)),
-            13 => Self::N13(Avx2Searcher13::new(needle)),
+        match *needle {
+            [] => Self::N0,
+            [c0] => Self::N1(MemchrSearcher::new(c0)),
+            [c0, c1] => Self::N2(Avx2Searcher::new([c0, c1])),
+            [c0, c1, c2] => Self::N3(Avx2Searcher::new([c0, c1, c2])),
+            [c0, c1, c2, c3] => Self::N4(Avx2Searcher::new([c0, c1, c2, c3])),
+            [c0, c1, c2, c3, c4] => Self::N5(Avx2Searcher::new([c0, c1, c2, c3, c4])),
+            [c0, c1, c2, c3, c4, c5] => Self::N6(Avx2Searcher::new([c0, c1, c2, c3, c4, c5])),
+            [c0, c1, c2, c3, c4, c5, c6] => {
+                Self::N7(Avx2Searcher::new([c0, c1, c2, c3, c4, c5, c6]))
+            }
+            [c0, c1, c2, c3, c4, c5, c6, c7] => {
+                Self::N8(Avx2Searcher::new([c0, c1, c2, c3, c4, c5, c6, c7]))
+            }
+            [c0, c1, c2, c3, c4, c5, c6, c7, c8] => {
+                Self::N9(Avx2Searcher::new([c0, c1, c2, c3, c4, c5, c6, c7, c8]))
+            }
+            [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9] => {
+                Self::N10(Avx2Searcher::new([c0, c1, c2, c3, c4, c5, c6, c7, c8, c9]))
+            }
+            [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10] => Self::N11(Avx2Searcher::new([
+                c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10,
+            ])),
+            [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11] => Self::N12(Avx2Searcher::new([
+                c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11,
+            ])),
+            [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12] => {
+                Self::N13(Avx2Searcher::new([
+                    c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12,
+                ]))
+            }
             _ => Self::N(Avx2Searcher::new(needle)),
         }
     }

--- a/tests/i386.rs
+++ b/tests/i386.rs
@@ -3,16 +3,21 @@ use std::{
     io::{BufRead, BufReader},
 };
 
-fn search(haystack: &str, needle: &str) {
-    let result = haystack.contains(&needle);
+fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
 
+fn search(haystack: &str, needle: &str) {
     let haystack = haystack.as_bytes();
     let needle = needle.as_bytes();
+
+    let result = find_subsequence(haystack, needle).is_some();
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     {
         use sliceslice::x86::DynamicAvx2Searcher;
-
         let searcher = unsafe { DynamicAvx2Searcher::new(needle.to_owned().into_boxed_slice()) };
         assert_eq!(unsafe { searcher.search_in(haystack) }, result);
     }


### PR DESCRIPTION
@zakcutner I took the time to push my proposal for a generic `Avx2Searcher`. I think having an associated constant the contain the static size of the needle is preferable as it convey the right information.

However the current code has small performance regressions in term of instructions:
* Around 1% for `long_haystack/DynamicAvx2Searcher::search_in`
* Around 3% for `short_haystack/DynamicAvx2Searcher::search_in`

I don 't really trust the wall time measurements because it vary too much on my machine from +/- 20% for the same code from run to run whereas the instruction measurements prove to be *very* reliable.

I haven't started investigating those regressions yet, but I wonder if it could result from the different calls to `as_ref()` we need to do to retrieve the needle slice.