### PR TITLE
Use `lto = true` and `codegen-units = 1` in benchmark profile

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -20,5 +20,6 @@ harness = false
 name = "random"
 harness = false
 
-[profile.release]
-debug = true
+[profile.bench]
+codegen-units = 1
+lto = true


### PR DESCRIPTION
This is to improve reproducibility of results