### PR TITLE
Disable perf benchmarks on non-Linux targets

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -6,11 +6,13 @@ publish = false
 
 [dependencies]
 criterion = "0.3"
-criterion-linux-perf = "0.1.0"
 memmem = "0.1"
 sliceslice = { path = ".." }
 sse4-strstr = { path = "sse4-strstr", optional = true }
 twoway = "0.2"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+criterion-linux-perf = "0.1"
 
 [[bench]]
 name = "i386"

--- a/bench/benches/i386.rs
+++ b/bench/benches/i386.rs
@@ -3,6 +3,7 @@ use criterion::{
     measurement::{Measurement, WallTime},
     Criterion,
 };
+#[cfg(target_os = "linux")]
 use criterion_linux_perf::{PerfMeasurement, PerfMode};
 use memmem::{Searcher, TwoWaySearcher};
 use std::{
@@ -171,10 +172,16 @@ criterion_group!(
     config = Criterion::default().with_measurement(WallTime);
     targets = search_short_haystack, search_long_haystack
 );
+
+#[cfg(target_os = "linux")]
 criterion_group!(
     name = i386_perf_instructions;
     config = Criterion::default().with_measurement(PerfMeasurement::new(PerfMode::Instructions));
     targets = search_short_haystack, search_long_haystack
 );
 
+#[cfg(target_os = "linux")]
 criterion_main!(i386_wall_time, i386_perf_instructions);
+
+#[cfg(not(target_os = "linux"))]
+criterion_main!(i386_wall_time);

--- a/bench/benches/random.rs
+++ b/bench/benches/random.rs
@@ -3,6 +3,7 @@ use criterion::{
     measurement::{Measurement, WallTime},
     BenchmarkId, Criterion,
 };
+#[cfg(target_os = "linux")]
 use criterion_linux_perf::{PerfMeasurement, PerfMode};
 use memmem::{Searcher, TwoWaySearcher};
 
@@ -85,10 +86,16 @@ criterion_group!(
     config = Criterion::default().with_measurement(WallTime);
     targets = search
 );
+
+#[cfg(target_os = "linux")]
 criterion_group!(
     name = random_perf_instructions;
     config = Criterion::default().with_measurement(PerfMeasurement::new(PerfMode::Instructions));
     targets = search
 );
 
+#[cfg(target_os = "linux")]
 criterion_main!(random_wall_time, random_perf_instructions);
+
+#[cfg(not(target_os = "linux"))]
+criterion_main!(random_wall_time);


### PR DESCRIPTION
Allows me to still run the benchmarks on my Mac which doesn't have `perf_event_open` 😛 