### PR TITLE
Add benchmarks against new `memchr::memmem` implementations

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies]
 criterion = "0.3"
+memchr = "2.4"
 memmem = "0.1"
 sliceslice = { path = ".." }
 sse4-strstr = { path = "sse4-strstr", optional = true }

--- a/bench/benches/i386.rs
+++ b/bench/benches/i386.rs
@@ -66,6 +66,21 @@ fn search_short_haystack<M: Measurement>(c: &mut Criterion<M>) {
         });
     });
 
+    group.bench_function("memchr::memmem::Finder::find", |b| {
+        let finders = needles
+            .iter()
+            .map(|&needle| memchr::memmem::Finder::new(needle.as_bytes()))
+            .collect::<Vec<_>>();
+
+        b.iter(|| {
+            for (i, finder) in finders.iter().enumerate() {
+                for haystack in &needles[i..] {
+                    black_box(finder.find(haystack.as_bytes()));
+                }
+            }
+        });
+    });
+
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     {
         use sliceslice::x86::DynamicAvx2Searcher;
@@ -150,6 +165,19 @@ fn search_haystack<M: Measurement>(
         b.iter(|| {
             for needle in &needles {
                 black_box(memchr::memmem::find(haystack, needle.as_bytes()));
+            }
+        });
+    });
+
+    group.bench_function("memchr::memmem::Finder::find", |b| {
+        let finders = needles
+            .iter()
+            .map(|needle| memchr::memmem::Finder::new(needle.as_bytes()))
+            .collect::<Vec<_>>();
+
+        b.iter(|| {
+            for finder in &finders {
+                black_box(finder.find(haystack));
             }
         });
     });

--- a/bench/benches/i386.rs
+++ b/bench/benches/i386.rs
@@ -56,6 +56,16 @@ fn search_short_haystack<M: Measurement>(c: &mut Criterion<M>) {
         });
     });
 
+    group.bench_function("memchr::memmem::find", |b| {
+        b.iter(|| {
+            for (i, needle) in needles.iter().enumerate() {
+                for haystack in &needles[i..] {
+                    black_box(memchr::memmem::find(haystack.as_bytes(), needle.as_bytes()));
+                }
+            }
+        });
+    });
+
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     {
         use sliceslice::x86::DynamicAvx2Searcher;
@@ -132,6 +142,14 @@ fn search_haystack<M: Measurement>(
         b.iter(|| {
             for needle in &needles {
                 black_box(twoway::find_bytes(haystack, needle.as_bytes()));
+            }
+        });
+    });
+
+    group.bench_function("memchr::memmem::find", |b| {
+        b.iter(|| {
+            for needle in &needles {
+                black_box(memchr::memmem::find(haystack, needle.as_bytes()));
             }
         });
     });

--- a/bench/benches/random.rs
+++ b/bench/benches/random.rs
@@ -57,6 +57,15 @@ fn search<M: Measurement>(c: &mut Criterion<M>) {
                 },
             );
 
+            group.bench_with_input(
+                BenchmarkId::new("memchr::memmem::Finder::find", parameter),
+                &size,
+                |b, _| {
+                    let finder = memchr::memmem::Finder::new(needle);
+                    b.iter(|| black_box(finder.find(haystack)));
+                },
+            );
+
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
             {
                 use sliceslice::x86::DynamicAvx2Searcher;

--- a/bench/benches/random.rs
+++ b/bench/benches/random.rs
@@ -49,6 +49,14 @@ fn search<M: Measurement>(c: &mut Criterion<M>) {
                 },
             );
 
+            group.bench_with_input(
+                BenchmarkId::new("memchr::memmem::find", parameter),
+                &size,
+                |b, _| {
+                    b.iter(|| black_box(memchr::memmem::find(haystack, needle)));
+                },
+            );
+
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
             {
                 use sliceslice::x86::DynamicAvx2Searcher;


### PR DESCRIPTION
Results:
```
short_haystack/memchr::memmem::find
                        time:   [1671827971 instructions 1671827976 instructions 1671827981 instructions]
long_haystack/memchr::memmem::find
                        time:   [256235298 instructions 256235300 instructions 256235303 instructions]
random_haystack/memchr::memmem::find
                        time:   [3276143 instructions 3276143 instructions 3276143 instructions]

short_haystack/memchr::memmem::Finder::find
                        time:   [1389031300 instructions 1389031304 instructions 1389031309 instructions]
long_haystack/memchr::memmem::Finder::find
                        time:   [254923877 instructions 254923879 instructions 254923880 instructions]
random_haystack/memchr::memmem::Finder::find
                        time:   [1964736 instructions 1964736 instructions 1964737 instructions]

short_haystack/DynamicAvx2Searcher::search_in
                        time:   [1010100472 instructions 1010100481 instructions 1010100491 instructions]
long_haystack/DynamicAvx2Searcher::search_in
                        time:   [239679929 instructions 239679930 instructions 239679931 instructions]
random_haystack/DynamicAvx2Searcher::search_in
                        time:   [1574708 instructions 1574708 instructions 1574708 instructions]
```

Summary:
* `short_haystack`: +65% instructions for `memchr::memmem::find` and +37% instructions for `memchr::memmem::Finder::find`
* `long_haystack`: +6% instructions for `memchr::memmem::find` and +6% instructions for `memchr::memmem::Finder::find`
* `random_haystack`: +108% instructions for `memchr::memmem::find` and +24% instructions for `memchr::memmem::Finder::find`

`memchr::memmem::Finder::find` is the API closest to what is currently being offered by `sliceslice` so is what matters here imo.