### PR TITLE
Make `DynamicAvx2Searcher` generic over it's needle type

### DIFF
--- a/bench/benches/i386.rs
+++ b/bench/benches/i386.rs
@@ -101,9 +101,7 @@ fn search_short_haystack<M: Measurement>(c: &mut Criterion<M>) {
         group.bench_function("DynamicAvx2Searcher::search_in", |b| {
             let searchers = needles
                 .iter()
-                .map(|&needle| unsafe {
-                    DynamicAvx2Searcher::new(needle.as_bytes().to_owned().into_boxed_slice())
-                })
+                .map(|&needle| unsafe { DynamicAvx2Searcher::new(needle.as_bytes()) })
                 .collect::<Vec<_>>();
 
             b.iter(|| {
@@ -198,9 +196,7 @@ fn search_haystack<M: Measurement>(
         group.bench_function("DynamicAvx2Searcher::search_in", |b| {
             let searchers = needles
                 .iter()
-                .map(|needle| unsafe {
-                    DynamicAvx2Searcher::new(needle.as_bytes().to_owned().into_boxed_slice())
-                })
+                .map(|needle| unsafe { DynamicAvx2Searcher::new(needle.as_bytes()) })
                 .collect::<Vec<_>>();
 
             b.iter(|| {

--- a/bench/benches/random.rs
+++ b/bench/benches/random.rs
@@ -85,9 +85,7 @@ fn search<M: Measurement>(c: &mut Criterion<M>) {
                     BenchmarkId::new("DynamicAvx2Searcher::search_in", parameter),
                     &size,
                     |b, _| {
-                        let searcher = unsafe {
-                            DynamicAvx2Searcher::new(needle.to_owned().into_boxed_slice())
-                        };
+                        let searcher = unsafe { DynamicAvx2Searcher::new(needle) };
                         b.iter(|| black_box(unsafe { searcher.search_in(haystack) }));
                     },
                 );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! ```
 //! use sliceslice::x86::DynamicAvx2Searcher;
 //!
-//! let searcher = unsafe { DynamicAvx2Searcher::new(b"ipsum".to_owned().into()) };
+//! let searcher = unsafe { DynamicAvx2Searcher::new(b"ipsum") };
 //!
 //! assert!(unsafe {
 //!     searcher.search_in(b"Lorem ipsum dolor sit amet, consectetur adipiscing elit")


### PR DESCRIPTION
We actually *don't need* to store a `Box<[u8]>` anymore in the generic case (i.e: the non specialized case, not  backed by an array) since we have a proper `Needle` trait implemented for `Box<[u8]>`.

It gives additional flexibility to the user and should also improve a bit some of the `oneshot` benchmarks discussed in #40 
