### PR TITLE
Introduce generic `Searcher` trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["search", "text", "string", "single", "simd"]
 
 [dependencies]
 memchr = "2.3"
+multiversion = { version = "0.6", default-features = false }
 seq-macro = "0.2"
 
 [dev-dependencies]

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -1,4 +1,7 @@
+#[allow(dead_code)]
 #[inline]
+#[multiversion::multiversion]
+#[clone(target = "[x86|x86_64]+avx2")]
 pub fn clear_leftmost_set(value: u32) -> u32 {
     value & (value - 1)
 }

--- a/src/memcmp.rs
+++ b/src/memcmp.rs
@@ -1,11 +1,17 @@
 use std::slice;
 
+#[allow(dead_code)]
 #[inline]
+#[multiversion::multiversion]
+#[clone(target = "[x86|x86_64]+avx2")]
 pub unsafe fn generic(left: *const u8, right: *const u8, n: usize) -> bool {
     slice::from_raw_parts(left, n) == slice::from_raw_parts(right, n)
 }
 
+#[allow(dead_code)]
 #[inline]
+#[multiversion::multiversion]
+#[clone(target = "[x86|x86_64]+avx2")]
 pub unsafe fn specialized<const N: usize>(left: *const u8, right: *const u8) -> bool {
     slice::from_raw_parts(left, N) == slice::from_raw_parts(right, N)
 }


### PR DESCRIPTION
Benchmark results:

* rust 1.57.0 - master

```
short_haystack/DynamicAvx2Searcher::search_in #2
                        time:   [738940753 instructions 738940753 instructions 738940754 instructions]

long_haystack/DynamicAvx2Searcher::search_in #2
                        time:   [236937801 instructions 236937801 instructions 236937801 instructions]

random_haystack/DynamicAvx2Searcher::search_in #2
                        time:   [1571817 instructions 1571817 instructions 1571817 instructions]
```

* rust 1.57.0 - generic-api

```
short_haystack/DynamicAvx2Searcher::search_in #2
                        time:   [738940746 instructions 738940747 instructions 738940748 instructions]

long_haystack/DynamicAvx2Searcher::search_in #2
                        time:   [236937746 instructions 236937747 instructions 236937747 instructions]

random_haystack/DynamicAvx2Searcher::search_in #2
                        time:   [1571768 instructions 1571768 instructions 1571768 instructions]
```