### PR TITLE
Add `aarch64` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,5 @@ memmap2 = "0.5"
 debug = true
 
 [features]
+aarch64 = []
 stdsimd = []

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -2,7 +2,10 @@
 #[multiversion::multiversion]
 #[clone(target = "[x86|x86_64]+avx2")]
 #[clone(target = "wasm32+simd128")]
-#[clone(target = "aarch64+neon")]
+#[cfg_attr(
+    all(target_arch = "aarch64", feature = "aarch64"),
+    clone(target = "aarch64+neon")
+)]
 pub fn clear_leftmost_set(value: u32) -> u32 {
     value & (value - 1)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,14 +7,14 @@
 #![warn(missing_docs)]
 // Will be stabilized in 1.61.0 with https://github.com/rust-lang/rust/pull/90621
 #![cfg_attr(
-    target_arch = "aarch64",
+    all(target_arch = "aarch64", feature = "aarch64"),
     allow(stable_features),
     feature(aarch64_target_feature)
 )]
 #![cfg_attr(feature = "stdsimd", feature(portable_simd))]
 
 /// Substring search implementations using aarch64 architecture features.
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", feature = "aarch64"))]
 pub mod aarch64;
 
 /// Substring search implementations using generic stdsimd features.
@@ -206,7 +206,10 @@ trait Searcher<N: NeedleWithSize + ?Sized> {
     #[multiversion::multiversion]
     #[clone(target = "[x86|x86_64]+avx2")]
     #[clone(target = "wasm32+simd128")]
-    #[clone(target = "aarch64+neon")]
+    #[cfg_attr(
+        all(target_arch = "aarch64", feature = "aarch64"),
+        clone(target = "aarch64+neon")
+    )]
     unsafe fn vector_search_in_chunk<V: Vector>(
         &self,
         hash: &VectorHash<V>,
@@ -260,7 +263,10 @@ trait Searcher<N: NeedleWithSize + ?Sized> {
     #[multiversion::multiversion]
     #[clone(target = "[x86|x86_64]+avx2")]
     #[clone(target = "wasm32+simd128")]
-    #[clone(target = "aarch64+neon")]
+    #[cfg_attr(
+        all(target_arch = "aarch64", feature = "aarch64"),
+        clone(target = "aarch64+neon")
+    )]
     unsafe fn vector_search_in<V: Vector>(
         &self,
         haystack: &[u8],

--- a/src/memcmp.rs
+++ b/src/memcmp.rs
@@ -4,7 +4,10 @@ use std::slice;
 #[multiversion::multiversion]
 #[clone(target = "[x86|x86_64]+avx2")]
 #[clone(target = "wasm32+simd128")]
-#[clone(target = "aarch64+neon")]
+#[cfg_attr(
+    all(target_arch = "aarch64", feature = "aarch64"),
+    clone(target = "aarch64+neon")
+)]
 pub unsafe fn generic(left: *const u8, right: *const u8, n: usize) -> bool {
     slice::from_raw_parts(left, n) == slice::from_raw_parts(right, n)
 }
@@ -13,7 +16,10 @@ pub unsafe fn generic(left: *const u8, right: *const u8, n: usize) -> bool {
 #[multiversion::multiversion]
 #[clone(target = "[x86|x86_64]+avx2")]
 #[clone(target = "wasm32+simd128")]
-#[clone(target = "aarch64+neon")]
+#[cfg_attr(
+    all(target_arch = "aarch64", feature = "aarch64"),
+    clone(target = "aarch64+neon")
+)]
 pub unsafe fn specialized<const N: usize>(left: *const u8, right: *const u8) -> bool {
     slice::from_raw_parts(left, N) == slice::from_raw_parts(right, N)
 }


### PR DESCRIPTION
This is done in order to fix compilation with stable compiler on
aarch64 architecture.