### PR TITLE
Build docs.rs documentation with `doc_auto_cfg`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ repository = "https://github.com/cloudflare/sliceslice-rs"
 license = "MIT"
 keywords = ["search", "text", "string", "single", "simd"]
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 cfg-if = "1"
 paste = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 
 #![warn(missing_docs)]
 #![cfg_attr(feature = "stdsimd", feature(portable_simd))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 /// Substring search implementations using aarch64 architecture features.
 #[cfg(target_arch = "aarch64")]


### PR DESCRIPTION
When building documentation for docs.rs, use the `doc_auto_cfg` feature to highlight which crate features are required for a given API. The feature is not used when building docs locally, as it requires the nightly toolchain (which docs.rs already uses).

You can check how the new docs will look by running:
```
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --open
```